### PR TITLE
fix: cubic backtracking in the css selector rule

### DIFF
--- a/examples/languages/test.css
+++ b/examples/languages/test.css
@@ -18,3 +18,6 @@ p > a,
 @media print {
 	body { font-size: 10pt }
 }
+
+.pointer-events-none,
+.overflow-wrap-anywhere

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -8,7 +8,7 @@ export default [
 	},
 	{
 		type: 'kwd',
-		match: /@\w+\b|\b(and|not|only|or)\b|\b[a-z-]+(?=[^{}]*{)/g
+		match: /@\w+\b|\b(and|not|only|or)\b|\b(?=([a-z-]+))\2(?=[^{}]*{)/g
 	},
 	{
 		type: 'var',


### PR DESCRIPTION
hey! on a css file with no `{` left ahead, the keyword rule goes cubic.

```js
await highlightText(readFileSync('docs/assets/style.css', 'utf8'), 'css')
```

that file is already in the repo (48.5 kB): **79 ms before, 7.7 ms after**, byte-identical output. a minified sheet ending on a licence banner, or a bare list of class names, is enough to trigger it — and `detect.js` classifies any braceless selector list as css, so it happens through markdown fences too.

cause: in `\b[a-z-]+(?=[^{}]*{)`, once the lookahead fails there is no `{` left, so `[a-z-]+` retries every length at every position. `\b(?=([a-z-]+))\2` pins the run inside a lookahead first, then consumes it — the usual atomic-group emulation, since js has no `(?>...)`.

+8 bytes in `css.js`. one fixture line in `test.css`.

### notes

- output is unchanged, not just on the fixtures: checked on the 17 `.css` files in the repo, on the same file embedded in `<style>` (html.js does `sub: 'css'`), and on 4000 random inputs.
- this is cubic → quadratic, not linear. `kwd` now costs what its neighbour `var` already cost — that rule shares the same lookahead and was always the floor.
- watch out for the `\2`: it is the *second* group, the first being the `(and|not|only|or)` alternation. adding a capturing group ahead of it would make the rule match the empty string, and since `index.js` skips empty matches the rule would silently stop working. worth a glance if that line is ever touched again.
- `log.js` has a similar quadratic in `[a-z_-]*exception`, but fixing it changes rendering (`socket-exception` stops being one token), so I left it out rather than smuggle it in here. happy to open it separately if you want it.
