### PR TITLE
fix: object key swallowing next key

### DIFF
--- a/examples/languages/test.js
+++ b/examples/languages/test.js
@@ -27,6 +27,7 @@ function test(test) {
 export default {
 	jsonData: a > 5,
 	match: /test/g,
+	headers: { 'Content-Type': 'text/html', 'Cache-Control': 'no-cache' },
 	type: `test
 	${'test'}hello
 	${test + 2.5}hello`,

--- a/examples/languages/test.json
+++ b/examples/languages/test.json
@@ -7,7 +7,8 @@
     "streetAddress": "21 2nd Street",
     "city": "New York",
     "state": "NY",
-    "postalCode": "10021-3100"
+    "postalCode": "10021-3100",
+    "country": { "code": "US", "name": "United States" }
   },
   "phone.numbers": [
     {

--- a/src/languages/js.js
+++ b/src/languages/js.js
@@ -1,6 +1,6 @@
 export default [
 	{ // js objects
-		match: /(("|')([^\r\n\\]|\\[^])*?\2|[a-zA-Z]\w*)(?=\s*:)/g
+		match: /(("|')((?!\2)[^\r\n\\]|\\[^])*\2|[a-zA-Z]\w*)(?=\s*:)/g
 	},
 	{ // jsdoc comments
 		match: /\/\*\*((?!\*\/)[^])*(\*\/)?/g,

--- a/src/languages/json.js
+++ b/src/languages/json.js
@@ -1,7 +1,7 @@
 export default [
 	{
 		type: 'var',
-		match: /(("|')([^\r\n\\]|\\[^])*?\2|[a-zA-Z]\w*)(?=\s*:)/g
+		match: /(("|')((?!\2)[^\r\n\\]|\\[^])*\2|[a-zA-Z]\w*)(?=\s*:)/g
 	},
 	{
 		expand: 'str'


### PR DESCRIPTION
hey! a quoted object key eats its own value **and** the next key whenever both sit on one line.

```js
await highlightText('{ "a": "x", "b": "y" }', 'json')
```

today `"x", "b"` is one `var` token; expected `str "x"`, `,`, `var "b"`. `src/index.js:148` is itself a case — the ternary there loses its colour.

cause: in `([^\r\n\\]|\\[^])*?\2` the class contains the quote, so the lazy run walks past the closing quote and stops at a later one followed by `:`. `((?!\2)[^\r\n\\]|\\[^])*\2` forbids it inside the run — the shape `str` already uses in `common.js`, backreference included.

+5 bytes in `json.js`, +5 in `js.js`, one fixture line in `test.js` and `test.json`; reverting either regex turns its own fixture red. `dist/` untouched.

### notes

- pretty-printed json never hit it, `[^\r\n]` stops at the newline — **zero change on the 36 existing fixtures**, `package-lock.json` byte-identical. minified input is where it shows: `dist/index.js` goes 1973 → 2579 tokens.
- also reaches `ts` and js embedded in `html` or md fences.
- not a ternary fix: `'in'` in `x ? 'in' : y` is still a key.
- the closing `\2` was already mandatory before this patch, so half-typed keys are unchanged. only malformed input like `{ "a: 1, "b": 2 }` moves, to what the `str` rule alone gives.
- timing cuts both ways: ~2-3x slower on a long line of dense `"key": "value"` pairs, since the run restarts at every string. but the old rule was quadratic with no `":` ahead — a json string array drops from seconds to ms, and `dist/index.js` from 1.16 to 0.74 ms.

happy to split it in two if you'd rather take json first :)
