### PR TITLE
fix: markdown headings, dash lists and table separators

### DIFF
--- a/examples/languages/test.md
+++ b/examples/languages/test.md
@@ -4,6 +4,11 @@ Heading
 Sub-heading
 -----------
 
+  Indented sub-heading
+  --------------------
+
+### Another deeper heading with **bold** and `code`
+
 Paragraphs are separated
 by a blank line.
 
@@ -41,12 +46,17 @@ Bullet list:
   * apples
   * oranges
   * pears
+  - dashes work too
+  + and pluses
+  *
 
 Numbered list:
 
   1. lather
   2. rinse
   3. repeat
+  4) or with a parenthesis
+  5.
 
 An [example](http://example.com). <http://example.com>
 

--- a/examples/languages/test.md
+++ b/examples/languages/test.md
@@ -7,6 +7,8 @@ Sub-heading
   Indented sub-heading
   --------------------
 
+## Sub heading
+
 ### Another deeper heading with **bold** and `code`
 
 Paragraphs are separated

--- a/src/languages/md.js
+++ b/src/languages/md.js
@@ -6,8 +6,10 @@ import { detectLanguage } from '../detect.js';
 
 export default /** @satisfies {import('../index.js').ShjGrammar} */ ([
 	{
+		// a single = can only underline a heading, while a single - is an empty
+		// list item, and the cmnt rule comes first so it would win that tie
 		type: 'cmnt',
-		match: /^>.*|^[ \t]*(=|-)\1+[ \t]*$/gm
+		match: /^>.*|^[ \t]*(=+|-{2,})[ \t]*$/gm
 	},
 	{
 		type: 'section',
@@ -18,7 +20,8 @@ export default /** @satisfies {import('../index.js').ShjGrammar} */ ([
 		match: /\*\*.*?\*\*/g
 	},
 	{
-		match: /^(`{3,})(.*)\n[^]*?^\1[ \t]*$/gm,
+		// the info string cannot be captured: sub only receives match[0]
+		match: /^(`{3,}).*\n[^]*?^\1[ \t]*$/gm,
 		sub: code => ({
 			type: 'kwd',
 			sub: [
@@ -31,21 +34,21 @@ export default /** @satisfies {import('../index.js').ShjGrammar} */ ([
 	},
 	{
 		type: 'str',
-		match: /`[^`]*`/g
+		match: /`[^`\n]*`/g
 	},
 	{
 		type: 'var',
 		match: /~~.*?~~/g
 	},
 	{
+		// emphasis, then list markers: sharing a type lets them share a regex,
+		// the alternation order keeps emphasis winning an equal start index
 		type: 'kwd',
-		match: /\b_\S([^\n]*?\S)?_\b|\*\S([^\n]*?\S)?\*/g
+		match: /\b_\S(.*?\S)?_\b|\*\S(.*?\S)?\*|^[ \t]*([*+-]|\d+[.)])([ \t]|$)/gm
 	},
 	{
-		type: 'kwd',
-		match: /^[ \t]*([*+-]|\d+[.)])([ \t]|$)/gm
-	},
-	{
+		// the type is not dead: with an array sub the tokenizer keeps the whole
+		// rule as data, so this colors what the sub leaves over (the url part)
 		type: 'func',
 		match: /\[[^\]]*]\([^)]*\)|<[^>]*>/g,
 		sub: [

--- a/src/languages/md.js
+++ b/src/languages/md.js
@@ -7,7 +7,11 @@ import { detectLanguage } from '../detect.js';
 export default /** @satisfies {import('../index.js').ShjGrammar} */ ([
 	{
 		type: 'cmnt',
-		match: /^>.*|(=|-)\1+/gm
+		match: /^>.*|^[ \t]*(=|-)\1+[ \t]*$/gm
+	},
+	{
+		type: 'section',
+		match: /^#{1,6}[ \t]/gm
 	},
 	{
 		type: 'class',
@@ -39,7 +43,7 @@ export default /** @satisfies {import('../index.js').ShjGrammar} */ ([
 	},
 	{
 		type: 'kwd',
-		match: /^\s*(\*|\d+\.)\s/gm
+		match: /^[ \t]*([*+-]|\d+[.)])([ \t]|$)/gm
 	},
 	{
 		type: 'func',


### PR DESCRIPTION
hey! found this highlighting a readme with `md`.

the `cmnt` rule `(=|-)\1+` isn't anchored, so it fires on any `--` or `==` in a line. your own readme hits it: every `|------|` in the language table is painted as a setext underline. `-`/`+` bullets, `1)` lists and atx headings had no rule.

```md
| name | class |
| ---- | ----- |
# heading
- dash bullet
+ plus
1) paren
foo -- bar
```

today only the `----` cells and the `--` are colored, as `cmnt`. expected: table row plain, `# ` as `section`, the three bullets as `kwd`.

fix: anchor `cmnt` to a whole line (`^[ \t]*(=|-)\1+[ \t]*$`), widen the list rule to `[*+-]` / `\d+[.)]`, add a `section` rule. the list rule ends with `([ \t]|$)` so a marker alone on its line stays lit while you type — same spirit as the optional closing delimiters elsewhere. +81 bytes, ~+69 minified (estimated). `test.md` updated; it's the only fixture that moves.

notes

- any `--`/`==` not alone on its line loses its `cmnt`: `i--`, `a == b`, `--verbose`, tables with or without outer pipes.
- token edges move: spaces around a setext underline now sit inside the span. same rendering, different snapshot.
- `   # heading` and a bare `#` stay uncolored, to keep 4-space code blocks dark.
- `section` isn't styled in `github-dim.css` or `termcolor.js` — pre-existing, but md makes it visible.
- happy to move `section` lower if you prefer the ini/toml ordering 🙂
