### PR TITLE
fix: diff file headers and unanchored ! in diff and git

### DIFF
--- a/examples/languages/test.diff
+++ b/examples/languages/test.diff
@@ -22,6 +22,11 @@
 > to this document.
 ! to this document.
 
+--- a/document.txt
++++ b/document.txt
 @@ -1 +1,2 @@
+ notice! It should
+--- a deleted comment
++++i, ++j;
 
 *** pos ***

--- a/examples/languages/test.git
+++ b/examples/languages/test.git
@@ -1,5 +1,7 @@
 git diff
 commit 526
+Merge branch 'main'
+fix: don't expand the quote
 --- before
 +++ after
 @@ -1 +1,2 @@
@@ -8,3 +10,4 @@ commit 526
 +test
 'string'
 "string"
+"unclosed

--- a/src/languages/diff.js
+++ b/src/languages/diff.js
@@ -1,5 +1,9 @@
 export default [
 	{
+		type: 'section',
+		match: /^@@.*@@$|^\d.*|^\*\*\*.*|^([+-])\1\1( \S+)?$/gm
+	},
+	{
 		type: 'deleted',
 		match: /^[-<].*/gm
 	},
@@ -9,10 +13,6 @@ export default [
 	},
 	{
 		type: 'kwd',
-		match: /!.*/gm
-	},
-	{
-		type: 'section',
-		match: /^@@.*@@$|^\d.*|^([*-+])\1\1.*/gm
+		match: /^!.*/gm
 	}
 ]

--- a/src/languages/git.js
+++ b/src/languages/git.js
@@ -6,7 +6,12 @@ export default [
 		sub: 'todo'
 	},
 	{
-		expand: 'str'
+		expand: 'strDouble'
+	},
+	{
+		// an apostrophe in prose is not a quote (ex: "don't")
+		type: 'str',
+		match: /(?<![\p{L}\p{N}])'[^'\r\n]*'?(?![\p{L}\p{N}])/gu
 	},
 	...diff,
 	{


### PR DESCRIPTION
hey! the two header lines of every `git diff` come out wrong.

```js
await highlightText('--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new', 'diff')
```

today `--- a/file` is `deleted` (red) and `+++ b/file` is `insert` (green), as if they were content lines. expected: both `section`, like the `@@` line.

cause: `[*-+]` in the section rule is a *range* (U+002A–U+002B), so it holds `*` and `+` but not `-`. `/[*-+]/.test('-')` is `false`. and even with the class fixed nothing moves, because the rule sat last and lost the index tie to `deleted`/`insert` — the loop runs backwards and takes `<=`. so the class and the position both have to change.

two more in the same pass:

- `/!.*/gm` was unanchored, so ` if (a !== b) {` painted `!== b) {` as a keyword mid-line. anchored to `^`.
- `git.js` used `expand: 'str'`, so every apostrophe in a commit message opened a green string. swapped for `strDouble` plus a prose-aware apostrophe rule.

+16 bytes in `diff.js`, +144 in `git.js`. fixture lines in `test.diff` and `test.git`.

### notes

- `--- <one word>` now reads `section` instead of `deleted`. that hits one-word deleted sql/lua comments (`-- up`, `-- down`) — common in migrations. `--- primary key` (two words) is unaffected. tightening further means reasoning about the `---`/`+++` pair, which costs a lot more than 16 bytes.
- paths with spaces (`--- a/my file.txt`) are *not* fixed — `( \S+)?$` wants a single token. no regression, main got them wrong too, but the fix is narrower than the title suggests.
- the apostrophe rule uses a lookbehind. `bash.js` already has four, one of them variable-length, so no new floor.
- escapes still work: `a "b\"c" d` is one string, same as before. half-typed quotes stay coloured too.
