### PR TITLE
fix: a trailing newline adds a phantom line number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ export async function highlightText(src, lang, multiline = true, opt = {}) {
 	await tokenize(src, lang, (str, type) => tmp += toSpan(sanitize(str), type))
 
 	return multiline
-		? `<div><div class="shj-numbers">${'<div></div>'.repeat(!opt.hideLineNumbers && src.split('\n').length)}</div><div>${tmp}</div></div>`
+		? `<div><div class="shj-numbers">${'<div></div>'.repeat(!opt.hideLineNumbers && src.replace(/\n$/, '').split('\n').length)}</div><div>${tmp}</div></div>`
 		: tmp;
 }
 


### PR DESCRIPTION
a code block whose source ends with a newline gets one line number too many.

```js
import { highlightText } from '@speed-highlight/core';

await highlightText('let a = 1\n', 'js')
```

today the gutter draws 2 numbers while the code column draws 1 line, so the last number sits next to nothing. expected is 1.

the count comes from `src.split('\n').length`, which counts the empty segment after the final `\n`. that segment gets no line box under `white-space: pre`, so it should get no number. the fix drops one trailing newline before counting, inline in the same expression, no new variable:

```js
src.replace(/\n$/, '').split('\n').length
```

`src/index.js` goes 6190 -> 6209 bytes (+19).

### notes

- only sources ending in `\n` change. everything else is byte for byte identical, `hideLineNumbers` and `multiline: false` included.
- `\r\n` is covered: `'a\r\nb\r\n'` gives 2. i checked the counts against the rendered height in chrome, not just the string.
- only one newline is stripped, so `'a\n\n'` still gives 2.
- `dist/` is untouched, so the published bundle keeps the bug until minify-bot regenerates it.
- no test ships with this. `package.json` only has `build`, and the fixtures in `examples/languages/` drive `tokenize`, not `highlightText`, so there was nowhere to hang it without inventing a suite. happy to add one if you want :)
- two older miscounts i left alone: an empty source still shows one number, and CR-only line endings still count as one line. both behave the same before and after this patch.
