### PR TITLE
docs: wait for setTheme in the node example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ npm i @speed-highlight/core
 ```js
 const { setTheme, printHighlight } = require('@speed-highlight/core/terminal');
 
-setTheme('[theme-name]');
-printHighlight('console.log("hello")', 'js');
+setTheme('[theme-name]').then(_ => {
+	printHighlight('console.log("hello")', 'js');
+});
 ```
 
 ## Migrating from prism


### PR DESCRIPTION
the node example in the readme calls `setTheme()` without waiting for it, so the theme is only applied by accident.

paste this:

```js
const { setTheme, printHighlight } = require('@speed-highlight/core/terminal');

setTheme('github-dark');
printHighlight('console.log("hello")', 'js');
```

today: prints the line in the **default** theme, then exits 1 with `Module not found in bundle: ./themes/github-dark.js`.
expected: no misleading output before the error.

the fix sequences the two calls, same shape as `examples/node-require/node.js`:

```js
setTheme('[theme-name]').then(_ => {
	printHighlight('console.log("hello")', 'js');
});
```

readme only, +16 bytes, nothing added to the bundle. titled `docs:` so it doesn't cut a release.

### notes

- with a valid theme name both forms render identical output today, so this isn't a rendering fix — it's consistency: the deno block above already awaits, and 4 of the 5 `setTheme` call sites in the repo already sequence. this one was the odd one out.
- behaviour change: with a bad name the old form prints wrongly-coloured output then exits 1, the new one prints nothing and exits 1. neither protects against a bad name.
- left alone, happy to open an issue instead: after a failed `setTheme`, `theme` stays a rejected promise, so a later unrelated `highlightText()` rejects too (`src/terminal.js:52`). fixing it costs bytes in the core, so it's your call.
- `termcolor` is a shipped terminal theme but is missing from the Themes table and from `ShjTerminalTheme`. separate change, not here.

thanks for the lib :)
