### PR TITLE
fix: export the language files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import { loadLanguage } from '../dist/index.js';
 loadLanguage('language-name', customLanguage);
 ```
 
-Preload a bundled language, so it is not fetched at highlight time
+Preload a bundled language
 
 ```js
 import { loadLanguage } from '@speed-highlight/core';

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ loadLanguage('language-name', customLanguage);
 ```
 
 Preload a bundled language, so it is not fetched at highlight time
-(also what to do when your bundler cannot resolve the dynamic import)
 
 ```js
 import { loadLanguage } from '@speed-highlight/core';

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ import { loadLanguage } from '../dist/index.js';
 loadLanguage('language-name', customLanguage);
 ```
 
+Preload a bundled language, so it is not fetched at highlight time
+(also what to do when your bundler cannot resolve the dynamic import)
+
+```js
+import { loadLanguage } from '@speed-highlight/core';
+import * as js from '@speed-highlight/core/languages/js.js';
+
+loadLanguage('js', js);
+```
+
 ---
 
 #### CDN

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
       "require": "./dist/node/terminal.js",
       "types": "./dist/terminal.d.ts"
     },
+    "./languages/*.js": {
+      "import": "./dist/languages/*.js",
+      "require": "./dist/node/languages/*.js",
+      "types": "./dist/languages/*.d.ts"
+    },
     "./themes/*.css": "./dist/themes/*.css"
   },
   "directories": {


### PR DESCRIPTION
the 105 language files are published to npm, but no specifier can reach them — `exports` has no entry for `./languages/*`.

paste this in a fresh folder, `npm i @speed-highlight/core`:

```js
await import('@speed-highlight/core/languages/js.js');       // ERR_PACKAGE_PATH_NOT_EXPORTED
await import('@speed-highlight/core/dist/languages/js.js');  // ERR_PACKAGE_PATH_NOT_EXPORTED
```

today: the files ship in the tarball but nothing can name them, so the only way in is a raw path into `node_modules` — which is what #46 ended up doing.
expected: `@speed-highlight/core/languages/js.js` resolves.

the fix is one entry, same shape as the `./themes/*.css` one right below it:

```json
"./languages/*.js": {
	"import": "./dist/languages/*.js",
	"require": "./dist/node/languages/*.js",
	"types": "./dist/languages/*.d.ts"
}
```

plus a readme block under *load custom language*, since preloading is now expressible:

```js
import { loadLanguage } from '@speed-highlight/core';
import * as js from '@speed-highlight/core/languages/js.js';

loadLanguage('js', js);
```

`langs[lang] ??= import(...)` then short-circuits, so the language is already there when `tokenize` runs instead of costing a round trip — which is what #27 asks for.

### verified

on a real `npm pack` tarball of this branch, not on the repo:

```
35/35 languages resolve            @speed-highlight/core/languages/<lang>.js
esm + cjs                          both render identical html
tsc --strict, moduleResolution nodenext   exit 0, no cast needed
., ./detect, ./terminal            unchanged
```

the cast in #46 (`as unknown as ShjLanguage`) is not needed once the path exists — the type was already right, only the path was closed.

### what this does *not* fix, to be accurate about #31

#31 reports two separate errors. this fixes the first one (`Missing "./dist/languages/log" specifier`), which still reproduces today.

the second one — the bundler not resolving `import(\`./languages/${lang}.js\`)` — **is no longer reproducible**. i built a real vite 8 production app against this repo: vite globs the directory by itself now and emits all 34 specifiers into the bundle, so the highlighting works with no plugin. that half of #31 was fixed upstream by vite, not here. worth knowing before you close it.

### notes

- the `*.js` suffix in the key is deliberate: it keeps the extension visible at the call site, like `./themes/*.css` does, and leaves `./languages/*` free if you ever want extensionless too
- no change to `src/`, no change to `dist/`, nothing added to the bundle
- closes #46 and #27, and the first half of #31 — happy to split it if you'd rather have the readme block separate
