### PR TITLE
feat: wrap line mode #21

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@
 /**
  * @typedef {Object} ShjOptions
  * @property {Boolean} [hideLineNumbers=false] Indicates whether to hide line numbers
+ * @property {Boolean} [wrap=false] Wrap long lines instead of scrolling horizontally
  */
 
 /**
@@ -125,12 +126,20 @@ export async function tokenize(src, lang, token) {
  * @returns {Promise<string>} The highlighted string
  */
 export async function highlightText(src, lang, multiline = true, opt = {}) {
-	let tmp = ''
-	await tokenize(src, lang, (str, type) => tmp += toSpan(sanitize(str), type))
+	// numbering a wrapped line needs its own grid row, so each line gets its own cell
+	let rows = multiline && opt.wrap && !opt.hideLineNumbers,
+		tmp = rows ? [''] : '';
+	await tokenize(src, lang, (str, type) => rows
+		? sanitize(str).split('\n').forEach((line, i) => i
+			? tmp.push(toSpan(line, type))
+			: tmp[tmp.length - 1] += toSpan(line, type))
+		: tmp += toSpan(sanitize(str), type))
 
-	return multiline
-		? `<div><div class="shj-numbers">${'<div></div>'.repeat(!opt.hideLineNumbers && src.split('\n').length)}</div><div>${tmp}</div></div>`
-		: tmp;
+	return rows
+		? `<div class="shj-wrap">${tmp.map(line => `<div class="shj-numbers"><div></div></div><div>${line}</div>`).join('')}</div>`
+		: multiline
+			? `<div${opt.wrap ? ' class="shj-wrap"' : ''}><div class="shj-numbers">${'<div></div>'.repeat(!opt.hideLineNumbers && src.split('\n').length)}</div><div>${tmp}</div></div>`
+			: tmp;
 }
 
 /**

--- a/src/themes/default.css
+++ b/src/themes/default.css
@@ -23,16 +23,21 @@
 [class*="shj-lang-"] ::selection {background: #bdf5}
 [class*="shj-lang-"] > div {
 	display: flex;
-	overflow: auto
+	overflow: auto;
+	counter-reset: line
 }
 [class*="shj-lang-"] > div :last-child {
 	flex: 1;
 	outline: none
 }
-.shj-numbers {
-	padding-left: 5px;
-	counter-reset: line
+[class*="shj-lang-"] > .shj-wrap {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	overflow: visible;
+	white-space: pre-wrap;
+	overflow-wrap: break-word
 }
+.shj-numbers {padding-left: 5px}
 .shj-numbers div {padding-right: 5px}
 .shj-numbers div::before {
 	color: #999;


### PR DESCRIPTION
`{ wrap: true }` on `highlightText` / `highlightElement` / `highlightAll`.

the reason this was never a one-liner: `white-space: pre-wrap` on the current markup wraps
the text fine, but the gutter is a separate column of one div per source line, so as soon as
a line wraps the numbers slide out of step with the code.

the middle panel is what people reach for today — by line 8 the gutter is lying:

![today scrolls horizontally, naive pre-wrap desynchronises the gutter, wrap mode stays aligned](https://raw.githubusercontent.com/lvolland/core/assets/wrap-demo.png)

so in wrap mode each line becomes its own grid row — number cell, code cell — and a token
that spans a newline is split at the newline so every cell stays balanced.

```js
highlightText(code, 'js', true, { wrap: true })
```

### cost

```
dist/index.js         +94 bytes gzipped
dist/themes/*.css     +58 bytes gzipped
```

nothing else changes: the css goes in `default.css`, which every other theme already
`@import`s, and the number cells keep the `shj-numbers` class so the six themes that
recolour the gutter keep working.

### verified

```
108/108   default output byte-identical to 1.2.19
          36 fixtures × { }, { hideLineNumbers }, multiline=false
36/36     wrap output: text reconstructs exactly, spans balanced inside every
          cell, one cell per source line
8/8       edge cases: empty, single line, crlf, trailing newline, only newlines,
          unterminated string, unterminated block comment, emoji + accents
```

### notes

- `{ wrap: true, hideLineNumbers: true }` needs no grid at all, so it keeps the current
  markup and only flips `white-space` — no per-line splitting, no extra bytes in the output
- `counter-reset: line` moves from `.shj-numbers` up to its parent. same result on the
  existing markup, and it lets the grid reuse the counter
- wrap mode inherits the trailing-newline behaviour from the default path — the phantom last
  number. #80 fixes that in the default path; happy to align both once you've picked a side
- i did not touch `dist/`
